### PR TITLE
Fixes for BPF programs

### DIFF
--- a/src/bpf/enclave.bpf.c
+++ b/src/bpf/enclave.bpf.c
@@ -86,8 +86,11 @@ static __always_inline u32 hash(const char *str, size_t len)
 	u32 hash = 0;
 	int i;
 
-	for (i = 0; i < len; i++)
+	for (i = 0; i < len; i++) {
+		if (str[i] == '\0')
+			return hash;
 		hash += str[i];
+	}
 
 	return hash;
 }


### PR DESCRIPTION
This PR contains two small fixes for BPF programs, which are going to unlock the follow-up work on #3

---

**bpf: Fix the hash function**

Before this change, the hash function didn't terminate on the end of
string.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>

---

**bpf: Check for runtime process after checking the parent**

This change changes the order of the process lookup. From now on, the
order is:

1) Check if the parent process is included in any container.
2) If no:
   a) Check whether the current process is a container runtime process.
   b) If yes, add a new container and register the new process.
      If no, nothing to do.
   If yes:
   a) Add the new process as a containerized process belonging to
      parent's container.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>