### PR TITLE
enclave: Make the list of runtime process comms configurable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,11 @@ name = "enclave"
 anyhow = "1.0"
 byteorder = "1.4"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
+config = { version = "0.11", default-features = false, features = ["toml"] }
+lazy_static = "1.4"
 libbpf-rs = "0.10"
 regex = { version = "1.5", default-features = false, features = ["perf"] }
+serde = "1.0"
 thiserror = "1.0"
 
 [build-dependencies]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,19 @@
+#[derive(Debug, serde::Deserialize)]
+pub struct Settings {
+    pub runtimes: Vec<String>,
+}
+
+impl Settings {
+    pub fn new() -> Result<Self, config::ConfigError> {
+	let mut s = config::Config::default();
+
+	s.set("runtimes", vec![
+	    "conmon".to_string(),
+	    "containerd-shim".into()
+	])?;
+
+	s.merge(config::File::with_name("/etc/enclave/enclave.toml").
+		required(false))?;
+	s.try_into()
+    }
+}


### PR DESCRIPTION
This change allows to configure the list of runtime processes through a
configuration file (`/etc/enclave/enclave.toml`). The default list is:

- conmon
- containerd-shim

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>