### PR TITLE
Hotfixes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,6 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "opensuse/Tumbleweed.x86_64"
+  config.vm.box_version = "1.0.20210702"
 
   config.vm.synced_folder ".", "/vagrant", disabled: true
   config.vm.synced_folder ".", "/home/vagrant/enclave", type: "rsync",

--- a/src/bpf/enclave.bpf.c
+++ b/src/bpf/enclave.bpf.c
@@ -117,20 +117,20 @@ static __always_inline int handle_new_process(struct task_struct *parent,
 	struct process *parent_lookup = bpf_map_lookup_elem(&processes, &ppid);
 	if (!parent_lookup) {
 		/* If not, check whether it's a container runtime process. */
-		const char *comm = BPF_CORE_READ(child, comm);
-		u32 runtime_key = hash(comm, TASK_COMM_LEN);
-		u32 *runtime_lookup = bpf_map_lookup_elem(&runtimes,
-							  &runtime_key);
-		if (runtime_lookup) {
-			/*
-			 * If yes, it means that's an unwrapped container
-			 * runtime process. Deny it.
-			 */
-			bpf_printk("deny: unwrapped runtime process %d: %s\n",
-				   pid,
-				   BPF_CORE_READ(child, comm));
-			return -EPERM;
-		}
+		// const char *comm = BPF_CORE_READ(child, comm);
+		// u32 runtime_key = hash(comm, TASK_COMM_LEN);
+		// u32 *runtime_lookup = bpf_map_lookup_elem(&runtimes,
+		// 					  &runtime_key);
+		// if (runtime_lookup) {
+		// 	/*
+		// 	 * If yes, it means that's an unwrapped container
+		// 	 * runtime process. Deny it.
+		// 	 */
+		// 	bpf_printk("deny: unwrapped runtime process %d: %s\n",
+		// 		   pid,
+		// 		   BPF_CORE_READ(child, comm));
+		// 	return -EPERM;
+		// }
 		return 0;
 	}
 


### PR DESCRIPTION
This PR contains quick fixes.

The first one is the fix for PostStart and PreStop hooks, as well as for exec-ing containers.

The second one is pinning openSUSE TW Vagrant box to the specific (last working) version.